### PR TITLE
Return error if storepath=cachepath

### DIFF
--- a/localfs_store.go
+++ b/localfs_store.go
@@ -26,6 +26,10 @@ type Localstore struct {
 
 func NewLocalStore(storepath, cachepath string, l logging.Logger) (*Localstore, error) {
 
+	if storepath == cachepath {
+		return nil, fmt.Errorf("storepath cannot be the same as cachepath")
+	}
+
 	err := os.MkdirAll(storepath, 0775)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create path. path=%s err=%v", storepath, err)

--- a/object_test.go
+++ b/object_test.go
@@ -124,7 +124,7 @@ func TestListObjs(t *testing.T) {
 	store := testutils.CreateStore(t)
 	testutils.Clearstore(t, store)
 	//
-	//Create 100 objects
+	//Create 20 objects
 	//
 	names := []string{}
 	for i := 0; i < 20; i++ {

--- a/store.go
+++ b/store.go
@@ -121,10 +121,13 @@ func cachepathObj(cachepath, oname, storeid string) string {
 	opath := path.Dir(oname)
 	ext := path.Ext(oname)
 	ext2 := fmt.Sprintf("%s.%s%s", ext, storeid, StoreCacheFileExt)
-	obase2 := strings.Replace(obase, ext, ext2, 1)
-	cn := path.Join(cachepath, opath, obase2)
-
-	return cn
+	var obase2 string
+	if ext == "" {
+		obase2 = obase + ext2
+	} else {
+		obase2 = strings.Replace(obase, ext, ext2, 1)
+	}
+	return path.Join(cachepath, opath, obase2)
 }
 
 func ensureDir(filename string) error {


### PR DESCRIPTION
Throws an error if storepath=cachepath in localstore
- also fixes cache file name if file has no extension.

Fixes #13