### PR TITLE
fixing the localfs reader writer truncate bug #52 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 google_jwt.json
+.env
+
 sniff* 

--- a/localfs/store.go
+++ b/localfs/store.go
@@ -244,7 +244,11 @@ func (l *LocalStore) NewWriterWithContext(ctx context.Context, o string, metadat
 		return nil, err
 	}
 
-	return csbufio.OpenWriter(fo)
+	f, err := os.OpenFile(fo, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0665)
+	if err != nil {
+		return nil, err
+	}
+	return csbufio.NewWriter(f), nil
 }
 
 func (l *LocalStore) Get(ctx context.Context, o string) (cloudstorage.Object, error) {

--- a/localfs/store_test.go
+++ b/localfs/store_test.go
@@ -45,5 +45,4 @@ func TestAll(t *testing.T) {
 	store, err = cloudstorage.NewStore(localFsConf)
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, nil, store)
-
 }

--- a/sftp/store.go
+++ b/sftp/store.go
@@ -557,6 +557,14 @@ func (m *Client) NewWriterWithContext(ctx context.Context, name string, metadata
 
 	name = strings.Replace(name, " ", "+", -1)
 
+	//	NewWriter should override any existing func
+	if !m.Exists(name) {
+		if err := m.Delete(ctx, name); err != nil {
+			gou.Errorf("failed to delete existing file %v %v", name, err)
+			return nil, err
+		}
+	}
+
 	// pr, pw := io.Pipe()
 	// bw := csbufio.NewWriter(pw)
 

--- a/sftp/store.go
+++ b/sftp/store.go
@@ -558,7 +558,7 @@ func (m *Client) NewWriterWithContext(ctx context.Context, name string, metadata
 	name = strings.Replace(name, " ", "+", -1)
 
 	//	NewWriter should override any existing func
-	if !m.Exists(name) {
+	if m.Exists(name) {
 		if err := m.Delete(ctx, name); err != nil {
 			gou.Errorf("failed to delete existing file %v %v", name, err)
 			return nil, err

--- a/sftp/store.go
+++ b/sftp/store.go
@@ -557,7 +557,7 @@ func (m *Client) NewWriterWithContext(ctx context.Context, name string, metadata
 
 	name = strings.Replace(name, " ", "+", -1)
 
-	//	NewWriter should override any existing func
+	//	NewWriter should override/truncate any existing file
 	if m.Exists(name) {
 		if err := m.Delete(ctx, name); err != nil {
 			gou.Errorf("failed to delete existing file %v %v", name, err)

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -694,8 +694,8 @@ func TestReadWriteCloser(t TestingT, store cloudstorage.Store) {
 		"",
 	}
 
-	// We do this twice because io writer should truncate and overwrite the object on
-	// the second loop.
+	// We do this multiple times with variable length data because NewWriter
+	// should truncate and overwrite the object on each call.
 	for i, padding := range testdata {
 		gou.Debugf("starting TestReadWriteCloser (take:%v)", i)
 		fileName := "prefix/iorw.test"

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -721,6 +721,9 @@ func TestReadWriteCloser(t TestingT, store cloudstorage.Store) {
 		assert.Equalf(t, nil, err, "at loop-cnt:%v", i)
 		assert.Equalf(t, data, buf2.String(), "round trip data don't match") // extra data means we didn't truncate the file
 
+		// make sure we clean up and close
+		assert.Equal(t, nil, rc.Close())
+
 		_, err = store.NewReader("bogus/notreal.csv")
 		assert.Equalf(t, cloudstorage.ErrObjectNotFound, err, "at loop-cnt:%v", i)
 	}

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -702,26 +702,26 @@ func TestReadWriteCloser(t TestingT, store cloudstorage.Store) {
 		data := fmt.Sprintf("%v:pid:%v:time:%v", padding, os.Getpid(), time.Now().Nanosecond())
 
 		wc, err := store.NewWriter(fileName, nil)
-		assert.Equal(t, nil, err)
+		assert.Equalf(t, nil, err, "at loop-cnt:%v", i)
 		buf1 := bytes.NewBufferString(data)
 		_, err = buf1.WriteTo(wc)
-		assert.Equal(t, nil, err)
+		assert.Equalf(t, nil, err, "at loop-cnt:%v", i)
 		err = wc.Close()
-		assert.Equal(t, nil, err)
+		assert.Equalf(t, nil, err, "at loop-cnt:%v", i)
 		time.Sleep(time.Millisecond * 100)
 
 		rc, err := store.NewReader(fileName)
-		assert.Equal(t, nil, err)
+		assert.Equalf(t, nil, err, "at loop-cnt:%v", i)
 		if rc == nil {
 			t.Fatalf("could not create reader")
 			return
 		}
 		buf2 := bytes.Buffer{}
 		_, err = buf2.ReadFrom(rc)
-		assert.Equal(t, nil, err)
-		assert.Equal(t, data, buf2.String(), "round trip data don't match") // extra data means we didn't truncate the file
+		assert.Equalf(t, nil, err, "at loop-cnt:%v", i)
+		assert.Equalf(t, data, buf2.String(), "round trip data don't match") // extra data means we didn't truncate the file
 
 		_, err = store.NewReader("bogus/notreal.csv")
-		assert.Equal(t, cloudstorage.ErrObjectNotFound, err)
+		assert.Equalf(t, cloudstorage.ErrObjectNotFound, err, "at loop-cnt:%v", i)
 	}
 }


### PR DESCRIPTION
fixes #52 

The localfs store wasn't correctly truncating the file when a new writer was created.  