### PR TITLE
Move should override dest files for localfs

### DIFF
--- a/azure/store.go
+++ b/azure/store.go
@@ -385,7 +385,7 @@ func (f *FS) NewWriterWithContext(ctx context.Context, name string, metadata map
 
 	o := &object{name: name, metadata: metadata}
 
-	rwc := newAzureWriteCloser(f, o)
+	rwc := newAzureWriteCloser(ctx, f, o)
 
 	return rwc, nil
 }
@@ -394,15 +394,15 @@ type azureWriteCloser struct {
 	pr *io.PipeReader
 	pw *io.PipeWriter
 	wc *bufio.Writer
-	g  errgroup.Group
+	g  *errgroup.Group
 }
 
 // azureWriteCloser is a io.WriteCloser that manages the azure connection pipe
-func newAzureWriteCloser(f *FS, obj *object) io.WriteCloser {
+func newAzureWriteCloser(ctx context.Context, f *FS, obj *object) io.WriteCloser {
 	pr, pw := io.Pipe()
 	bw := bufio.NewWriter(pw)
 
-	var g errgroup.Group
+	g, _ := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
 		// Upload the file to azure.

--- a/go.test.sh
+++ b/go.test.sh
@@ -3,8 +3,6 @@
 set -e
 echo "" > coverage.txt
 
-go test `go list ./... | grep localfs`
-
 for d in $(go list ./... | grep -v vendor  | sort -r); do
     go test -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then

--- a/go.test.sh
+++ b/go.test.sh
@@ -3,7 +3,9 @@
 set -e
 echo "" > coverage.txt
 
-for d in $(go list ./... | grep -v vendor); do
+go test `go list ./... | grep localfs`
+
+for d in $(go list ./... | grep -v vendor  | sort -r); do
     go test -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt

--- a/go.test.sh
+++ b/go.test.sh
@@ -4,7 +4,7 @@ set -e
 echo "" > coverage.txt
 
 for d in $(go list ./... | grep -v vendor  | sort -r); do
-    go test -race -coverprofile=profile.out -covermode=atomic $d
+    go test -timeout=5m -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
         rm profile.out

--- a/localfs/store_test.go
+++ b/localfs/store_test.go
@@ -1,6 +1,7 @@
 package localfs_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,10 @@ import (
 )
 
 func TestAll(t *testing.T) {
+
+	os.RemoveAll("/tmp/mockcloud")
+	os.RemoveAll("/tmp/localcache")
+
 	localFsConf := &cloudstorage.Config{
 		Type:       localfs.StoreType,
 		AuthMethod: localfs.AuthFileSystem,

--- a/sftp/store.go
+++ b/sftp/store.go
@@ -816,6 +816,12 @@ func (o *object) Sync() error {
 	}
 	o.cachedcopy = cachedcopy
 	//gou.DebugCtx(o.client.clientCtx, "Uploaded %q size=%d", o.name, size)
+
+	err = cachedcopy.Close()
+	if err != nil {
+		return fmt.Errorf("error on closing localfile. %q err=%v", o.cachepath, err)
+	}
+
 	return nil
 }
 
@@ -835,10 +841,10 @@ func (o *object) Close() error {
 			gou.Errorf("error on sync file=%q err=%v", o.name, err)
 			return err
 		}
-	} else {
-		gou.Debugf("not syncing on close? %v opened?%v  readonly?%v", o.name, o.opened, o.readonly)
+		return nil
 	}
 
+	gou.Debugf("not syncing on close? %v opened?%v  readonly?%v", o.name, o.opened, o.readonly)
 	err := o.cachedcopy.Close()
 	if err != nil {
 		return fmt.Errorf("error on sync and closing localfile. %q err=%v", o.cachepath, err)

--- a/store.go
+++ b/store.go
@@ -320,7 +320,7 @@ func Move(ctx context.Context, s Store, src, des Object) error {
 		gou.Warnf("Move could not open source %v err=%v", src.Name(), err)
 		return err
 	}
-	if _, err = io.Copy(fout, fin); err != nil {
+	if _, err := io.Copy(fout, fin); err != nil {
 		return err
 	}
 	if err := des.Close(); err != nil {

--- a/store.go
+++ b/store.go
@@ -280,58 +280,58 @@ func Move(ctx context.Context, s Store, src, des Object) error {
 		}
 	}
 
-	//	// Slow path, copy locally then up to des
-	//	srcPath := src.Name()
-	//	desPath := des.Name()
-	//  fout, err := s.NewWriterWithContext(ctx, desPath, src.MetaData())
-	//	if err != nil {
-	//		gou.Warnf("Move could not open destination %v", src.Name())
-	//		return err
-	//	}
-	//	fin, err := s.NewReaderWithContext(ctx, srcPath)
-	//	if err != nil {
-	//		gou.Warnf("Move could not open source %v err=%v", src.Name(), err)
-	//	}
-	//	if _, err = io.Copy(fout, fin); err != nil {
-	//		return err
-	//	}
-	//	if err := fin.Close(); err != nil {
-	//		return err
-	//	}
-	//	if err := fout.Close(); err != nil { //this will flush and sync the file.
-	//		return err
-	//	}
-	//	if err := src.Delete(); err != nil { //delete the src, after des has been flushed/synced
-	//		return err
-	//	}
-
 	// Slow path, copy locally then up to des
-	fout, err := des.Open(ReadWrite)
+	srcPath := src.Name()
+	desPath := des.Name()
+	fout, err := s.NewWriterWithContext(ctx, desPath, src.MetaData())
 	if err != nil {
 		gou.Warnf("Move could not open destination %v", src.Name())
 		return err
 	}
-	if err := fout.Truncate(0); err != nil {
+	fin, err := s.NewReaderWithContext(ctx, srcPath)
+	if err != nil {
+		gou.Warnf("Move could not open source %v err=%v", src.Name(), err)
+	}
+	if _, err = io.Copy(fout, fin); err != nil {
+		return err
+	}
+	if err := fin.Close(); err != nil {
+		return err
+	}
+	if err := fout.Close(); err != nil { //this will flush and sync the file.
+		return err
+	}
+	if err := src.Delete(); err != nil { //delete the src, after des has been flushed/synced
 		return err
 	}
 
-	fin, err := src.Open(ReadOnly)
-	if err != nil {
-		gou.Warnf("Move could not open source %v err=%v", src.Name(), err)
-		return err
-	}
-	if _, err := io.Copy(fout, fin); err != nil {
-		return err
-	}
-	if err := des.Close(); err != nil {
-		return err
-	}
-	if err := src.Close(); err != nil {
-		return err
-	}
-	if err := src.Delete(); err != nil {
-		return err
-	}
+	//	// Slow path, copy locally then up to des
+	//	fout, err := des.Open(ReadWrite)
+	//	if err != nil {
+	//		gou.Warnf("Move could not open destination %v", src.Name())
+	//		return err
+	//	}
+	//	if err := fout.Truncate(0); err != nil {
+	//		return err
+	//	}
+	//
+	//	fin, err := src.Open(ReadOnly)
+	//	if err != nil {
+	//		gou.Warnf("Move could not open source %v err=%v", src.Name(), err)
+	//		return err
+	//	}
+	//	if _, err := io.Copy(fout, fin); err != nil {
+	//		return err
+	//	}
+	//	if err := des.Close(); err != nil {
+	//		return err
+	//	}
+	//	if err := src.Close(); err != nil {
+	//		return err
+	//	}
+	//	if err := src.Delete(); err != nil {
+	//		return err
+	//	}
 
 	return nil
 }

--- a/store.go
+++ b/store.go
@@ -257,7 +257,9 @@ func Copy(ctx context.Context, s Store, src, des Object) error {
 	}
 
 	// Slow path, open an io.Reader from the source and copy it to an
-	// io.Writer as the destination
+	// io.Writer to the destination.  This is considered a "slow path" because we
+	// have to act as a broker to relay bytes between the two objects.  Some
+	// stores support moving data using an API call.
 	fout, err := s.NewWriterWithContext(ctx, des.Name(), src.MetaData())
 	if err != nil {
 		gou.Warnf("Move could not open destination %v", src.Name())

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -269,21 +269,22 @@ func Move(t TestingT, store cloudstorage.Store) {
 
 		ensureContents(t, store, "to/testmove.txt", data, fmt.Sprintf("move `to` file validation: at row:%v", row))
 
-		ensureContents(t, store, "from/testmove.txt", data, fmt.Sprintf("move `from` file validation: at row:%v", row))
+		_, err := store.Get(context.Background(), "from/testmove.txt")
+		assert.Equal(t, cloudstorage.ErrObjectNotFound, err, "move `from` file validation: at row:%v", row)
 	}
 }
 
 func ensureContents(t TestingT, store cloudstorage.Store, name, data, msg string) {
-	obj2, err := store.Get(context.Background(), "to/testmove.txt")
+	obj, err := store.Get(context.Background(), name)
 	assert.Equal(t, nil, err, msg)
-	assert.Equal(t, store.Type(), obj2.StorageSource(), msg)
-	assert.Equal(t, "to/testmove.txt", obj2.Name(), msg)
+	assert.Equal(t, store.Type(), obj.StorageSource(), msg)
+	assert.Equal(t, name, obj.Name(), msg)
 
-	f2, err := obj2.Open(cloudstorage.ReadOnly)
+	f, err := obj.Open(cloudstorage.ReadOnly)
 	assert.Equal(t, nil, err, msg)
-	assert.Equal(t, fmt.Sprintf("%p", f2), fmt.Sprintf("%p", obj2.File()), msg)
+	assert.Equal(t, fmt.Sprintf("%p", f), fmt.Sprintf("%p", obj.File()), msg)
 
-	bytes, err := ioutil.ReadAll(f2)
+	bytes, err := ioutil.ReadAll(f)
 	assert.Equal(t, nil, err, msg)
 	assert.Equal(t, data, string(bytes), msg)
 }

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -236,6 +236,9 @@ func Move(t TestingT, store cloudstorage.Store) {
 	case "azure":
 		// wtf, eff you azure.
 		time.Sleep(time.Millisecond * 1100)
+	case "sftp":
+		t.Logf("SKIPPING MOVE tests for SFTP")
+		return
 	}
 
 	testdata := []string{

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -241,8 +241,9 @@ func Move(t TestingT, store cloudstorage.Store) {
 		// wtf, eff you azure.
 		time.Sleep(time.Millisecond * 1100)
 	case "sftp":
-		t.Logf("SKIPPING MOVE tests for SFTP")
-		return
+		time.Sleep(time.Millisecond * 1100)
+		//t.Logf("SKIPPING MOVE tests for SFTP")
+		//return
 	}
 
 	testdata := []string{

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -743,7 +743,7 @@ func TestReadWriteCloser(t TestingT, store cloudstorage.Store) {
 		buf2 := bytes.Buffer{}
 		_, err = buf2.ReadFrom(rc)
 		assert.Equalf(t, nil, err, "at loop-cnt:%v", i)
-		assert.Equalf(t, data, buf2.String(), "round trip data don't match") // extra data means we didn't truncate the file
+		assert.Equalf(t, data, buf2.String(), "round trip data don't match: loop-cnt:%v", i) // extra data means we didn't truncate the file
 
 		// make sure we clean up and close
 		assert.Equal(t, nil, rc.Close())

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -79,6 +79,10 @@ func Clearstore(t TestingT, store cloudstorage.Store) {
 	}
 
 	switch store.Type() {
+	case "s3":
+		// S3 maybe lazy about deletes...
+		fmt.Println("doing s3 delete sleep 5")
+		time.Sleep(5 * time.Second)
 	case "gcs":
 		// GCS is lazy about deletes...
 		fmt.Println("doing GCS delete sleep 15")
@@ -87,8 +91,6 @@ func Clearstore(t TestingT, store cloudstorage.Store) {
 }
 
 func RunTests(t TestingT, s cloudstorage.Store) {
-
-	gou.SetLogger(log.New(os.Stderr, "", log.Ldate|log.Lmicroseconds|log.Lshortfile), "debug")
 
 	t.Logf("running store setup: type:%v", s.Type())
 	StoreSetup(t, s)
@@ -461,7 +463,7 @@ func ListObjsAndFolders(t TestingT, store cloudstorage.Store) {
 	createObjects := func(names []string) {
 		for _, n := range names {
 			obj, err := store.NewObject(n)
-			assert.Equal(t, nil, err)
+			assert.Equalf(t, nil, err, "failed trying to call new object on:%v of %v", n, names)
 			if obj == nil {
 				continue
 			}

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -267,6 +267,8 @@ func Move(t TestingT, store cloudstorage.Store) {
 		err = cloudstorage.Move(context.Background(), store, obj, dest)
 		assert.Equal(t, nil, err, "at row:%v", row)
 
+		time.Sleep(time.Millisecond * 500) //uggg
+
 		ensureContents(t, store, "to/testmove.txt", data, fmt.Sprintf("move `to` file validation: at row:%v", row))
 
 		_, err := store.Get(context.Background(), "from/testmove.txt")

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -88,6 +88,8 @@ func Clearstore(t TestingT, store cloudstorage.Store) {
 
 func RunTests(t TestingT, s cloudstorage.Store) {
 
+	gou.SetLogger(log.New(os.Stderr, "", log.Ldate|log.Lmicroseconds|log.Lshortfile), "debug")
+
 	t.Logf("running store setup: type:%v", s.Type())
 	StoreSetup(t, s)
 	gou.Debugf("finished StoreSetup")

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -723,7 +723,7 @@ func TestReadWriteCloser(t TestingT, store cloudstorage.Store) {
 	for i, padding := range testdata {
 		gou.Debugf("starting TestReadWriteCloser (take:%v)", i)
 		fileName := "prefix/iorw.test"
-		data := fmt.Sprintf("%v:pid:%v:time:%v", padding, os.Getpid(), time.Now().Nanosecond())
+		data := fmt.Sprintf("pad:%v:pid:%v:time:%v:index:%v:", padding, os.Getpid(), time.Now().Nanosecond(), i)
 
 		wc, err := store.NewWriter(fileName, nil)
 		assert.Equalf(t, nil, err, "at loop-cnt:%v", i)

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -277,6 +277,9 @@ func Move(t TestingT, store cloudstorage.Store) {
 func ensureContents(t TestingT, store cloudstorage.Store, name, data, msg string) {
 	obj, err := store.Get(context.Background(), name)
 	assert.Equal(t, nil, err, msg)
+	if err != nil {
+		return
+	}
 	assert.Equal(t, store.Type(), obj.StorageSource(), msg)
 	assert.Equal(t, name, obj.Name(), msg)
 

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -88,7 +88,7 @@ func Clearstore(t TestingT, store cloudstorage.Store) {
 
 func RunTests(t TestingT, s cloudstorage.Store) {
 
-	t.Logf("running store setup")
+	t.Logf("running store setup: type:%v", s.Type())
 	StoreSetup(t, s)
 	gou.Debugf("finished StoreSetup")
 

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -284,6 +284,10 @@ func ensureContents(t TestingT, store cloudstorage.Store, name, data, msg string
 	assert.Equal(t, name, obj.Name(), msg)
 
 	f, err := obj.Open(cloudstorage.ReadOnly)
+	defer func() {
+		err = obj.Close()
+		assert.Equal(t, nil, err, msg)
+	}()
 	assert.Equal(t, nil, err, msg)
 	assert.Equal(t, fmt.Sprintf("%p", f), fmt.Sprintf("%p", obj.File()), msg)
 


### PR DESCRIPTION
Closes #73 

Fixes the following issues:

- localfs wasn't correctly truncating the "store" file before moving over it.  The result is that data could get corrupted when it's overwritten.
- adding more tests that deal with variable length data sets, so that we can detect truncation issues.  
- Fix a race condition in azures, such that it wasn't managing a go routine that flushed data to the backing store.
- Performance improvement for the Copy and Move functions.  They now use io Reader/Writers to stream data from a src->des, instead of copying the data to a local file and then uploading that local file to the des.