### PR TITLE
fix issue #66 aws-s3 paging/next-marker is not correct

### DIFF
--- a/awss3/store.go
+++ b/awss3/store.go
@@ -307,7 +307,7 @@ func (f *FS) List(ctx context.Context, q cloudstorage.Query) (*cloudstorage.Obje
 	}
 
 	if resp.IsTruncated != nil && *resp.IsTruncated {
-		q.Marker = *resp.Contents[len(resp.Contents)-1].Key
+		objResp.NextMarker = q.Marker = *resp.Contents[len(resp.Contents)-1].Key
 	}
 
 	return objResp, nil

--- a/awss3/store.go
+++ b/awss3/store.go
@@ -307,7 +307,9 @@ func (f *FS) List(ctx context.Context, q cloudstorage.Query) (*cloudstorage.Obje
 	}
 
 	if resp.IsTruncated != nil && *resp.IsTruncated {
-		objResp.NextMarker = q.Marker = *resp.Contents[len(resp.Contents)-1].Key
+		lastObj := *resp.Contents[len(resp.Contents)-1].Key
+		objResp.NextMarker = lastObj
+		q.Marker = lastObj
 	}
 
 	return objResp, nil


### PR DESCRIPTION
I am not sure if I can provide a unit test for this case, my problem is iterate over a huge s3 bucket without manually handle the next marker