### PR TITLE
merge fix for aws-s3 next-page-marker

### DIFF
--- a/awss3/store.go
+++ b/awss3/store.go
@@ -307,7 +307,8 @@ func (f *FS) List(ctx context.Context, q cloudstorage.Query) (*cloudstorage.Obje
 	}
 
 	if resp.IsTruncated != nil && *resp.IsTruncated {
-		q.Marker = *resp.Contents[len(resp.Contents)-1].Key
+		lastObj := *resp.Contents[len(resp.Contents)-1].Key
+		objResp.NextMarker = lastObj
 	}
 
 	return objResp, nil


### PR DESCRIPTION
closes #66 

I was originally going to merge in as part of https://github.com/lytics/cloudstorage/pull/70 BUT, that opened up a can of worms in the localfs based storage component, so going to merge in this direct to master while working on that.