### PR TITLE
add more config validation and test for config errors

### DIFF
--- a/google/google_test.go
+++ b/google/google_test.go
@@ -3,8 +3,10 @@ package google_test
 import (
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
+	"cloud.google.com/go/storage"
 	"github.com/lytics/cloudstorage"
 	"github.com/lytics/cloudstorage/google"
 	"github.com/lytics/cloudstorage/testutils"
@@ -48,4 +50,74 @@ func TestAll(t *testing.T) {
 		t.Fatalf("Could not create store: config=%+v  err=%v", config, err)
 	}
 	testutils.RunTests(t, store, config)
+}
+
+func TestConfigValidation(t *testing.T) {
+
+	// VALIDATE errors for AuthJWTKeySource
+	config := &cloudstorage.Config{}
+	_, err := cloudstorage.NewStore(config)
+	if err == nil {
+		t.Fatalf("expected an error for an empty config: config=%+v", config)
+	}
+
+	jc := &cloudstorage.JwtConf{}
+	config.JwtConf = jc
+
+	_, err = cloudstorage.NewStore(config)
+	if err == nil {
+		t.Fatalf("expected an error for an empty config: config=%+v", config)
+	}
+
+	config = &cloudstorage.Config{
+		Type:       google.StoreType,
+		AuthMethod: google.AuthJWTKeySource,
+		Project:    "tbd",
+		Bucket:     "liotesting-int-tests-nl",
+		TmpDir:     "/tmp/localcache/google",
+	}
+
+	_, err = cloudstorage.NewStore(config)
+	if err == nil {
+		t.Fatalf("expected an error for a config without a JwtConfig: config=%+v", config)
+	}
+
+	config.Type = ""
+	_, err = cloudstorage.NewStore(config)
+	if err == nil {
+		t.Fatalf("expected an error for a config without a Type: config=%+v", config)
+	}
+	if !strings.Contains(err.Error(), "Type is required on Config") {
+		t.Fatalf("expected error `Type is required on Config`: err=%v", err)
+	}
+
+	config.Type = google.StoreType
+	config.AuthMethod = ""
+	_, err = cloudstorage.NewStore(config)
+	if err == nil {
+		t.Fatalf("expected an error for a config without a AuthMethod: config=%+v", config)
+	}
+	if !strings.Contains(err.Error(), "bad AuthMethod") {
+		t.Fatalf("expected error `bad AuthMethod`: err=%v", err)
+	}
+
+	// VALIDATE errors for AuthGoogleJWTKeySource (used to load a config from a JWT file)
+	config = &cloudstorage.Config{
+		Type:       google.StoreType,
+		AuthMethod: google.AuthGoogleJWTKeySource,
+		Project:    "tbd",
+		Bucket:     "tbd",
+		TmpDir:     "/tmp/tbd",
+		JwtFile:    "./jwt.json",
+	}
+	_, err = cloudstorage.NewStore(config)
+	if err == nil {
+		t.Fatalf("expected an error for a config without a scopes: config=%+v", config)
+	}
+
+	config.Scope = storage.ScopeReadWrite
+	_, err = cloudstorage.NewStore(config)
+	if err == nil {
+		t.Fatalf("expected an error for a config that points to a non-existent file: config=%+v", config)
+	}
 }

--- a/store.go
+++ b/store.go
@@ -341,5 +341,8 @@ func (j *JwtConf) fixKey() {
 	}
 }
 func (j *JwtConf) KeyBytes() ([]byte, error) {
+	if j.PrivateKey == "" {
+		return nil, fmt.Errorf("invalid config, private key empty")
+	}
 	return base64.StdEncoding.DecodeString(j.PrivateKey)
 }


### PR DESCRIPTION
Small change to fix #76 

- adds test around our config validation. 
- fixes error if an AuthGoogleJWTKeySource config is created without a scope.
- fixes a panic if you create a AuthJWTKeySource config without JwtConf.