### PR TITLE
add setters for bucket-level access control and lifecyle

### DIFF
--- a/google/apistore.go
+++ b/google/apistore.go
@@ -59,3 +59,29 @@ func (c *APIStore) AddReader(bucket, object, entity string) error {
 	_, err := c.service.ObjectAccessControls.Insert(bucket, object, ac).Do()
 	return err
 }
+
+// AddBucketReader adds a writer of the bucket
+func (c *APIStore) AddBucketReader(bucket, entity string) error {
+	ac := &storage.BucketAccessControl{Entity: entity, Role: "READER"}
+	_, err := c.service.BucketAccessControls.Insert(bucket, ac).Do()
+	return err
+}
+
+// AddBucketWriter adds a writer of the bucket
+func (c *APIStore) AddBucketWriter(bucket, entity string) error {
+	ac := &storage.BucketAccessControl{Entity: entity, Role: "WRITER"}
+	_, err := c.service.BucketAccessControls.Insert(bucket, ac).Do()
+	return err
+}
+
+// SetBucketLifecycle updates a bucket lifecycle policy in days
+func (c *APIStore) SetBucketLifecycle(name string, days int64) error {
+	bucket := &storage.Bucket{Name: name}
+	bucket.Lifecycle = new(storage.BucketLifecycle)
+	action := &storage.BucketLifecycleRuleAction{Type: "Delete"}
+	condition := &storage.BucketLifecycleRuleCondition{Age: days}
+	bucket.Lifecycle.Rule = make([]*storage.BucketLifecycleRule, 1)
+	bucket.Lifecycle.Rule[0] = &storage.BucketLifecycleRule{Action: action, Condition: condition}
+	_, err := c.service.Buckets.Patch(name, bucket).Do()
+	return err
+}

--- a/google/apistore.go
+++ b/google/apistore.go
@@ -60,7 +60,7 @@ func (c *APIStore) AddReader(bucket, object, entity string) error {
 	return err
 }
 
-// AddBucketReader adds a writer of the bucket
+// AddBucketReader adds a reader of the bucket
 func (c *APIStore) AddBucketReader(bucket, entity string) error {
 	ac := &storage.BucketAccessControl{Entity: entity, Role: "READER"}
 	_, err := c.service.BucketAccessControls.Insert(bucket, ac).Do()

--- a/google/apistore.go
+++ b/google/apistore.go
@@ -74,8 +74,8 @@ func (c *APIStore) AddBucketWriter(bucket, entity string) error {
 	return err
 }
 
-// SetBucketLifecycle updates a bucket lifecycle policy in days
-func (c *APIStore) SetBucketLifecycle(name string, days int64) error {
+// SetBucketAgeLifecycle updates a bucket-level lifecycle policy for object age in days
+func (c *APIStore) SetBucketAgeLifecycle(name string, days int64) error {
 	bucket := &storage.Bucket{Name: name}
 	bucket.Lifecycle = new(storage.BucketLifecycle)
 	action := &storage.BucketLifecycleRuleAction{Type: "Delete"}


### PR DESCRIPTION
implements setter methods for bucket-level permissions and lifecycle policy:
- `AddBucketReader`
- `AddBucketWriter`
- `SetBucketLifecycle`