### PR TITLE
add endpoint configuration for aws s3 to be used in yandex s3

### DIFF
--- a/awss3/store.go
+++ b/awss3/store.go
@@ -123,6 +123,10 @@ func NewClient(conf *cloudstorage.Config) (*s3.S3, *session.Session, error) {
 		awsConf.WithRegion("us-east-1")
 	}
 
+	if conf.Endpoint != "" {
+		awsConf.WithEndpoint(conf.Endpoint)
+	}
+
 	switch conf.AuthMethod {
 	case AuthAccessKey:
 		accessKey := conf.Settings.String(ConfKeyAccessKey)

--- a/store.go
+++ b/store.go
@@ -181,6 +181,8 @@ type (
 		Project string
 		// Region is the cloud region
 		Region string
+		// Endpoint is the api endpoint
+		Endpoint string
 		// Bucket is the "path" or named bucket in cloud
 		Bucket string
 		// the page size to use with api requests (default 1000)


### PR DESCRIPTION
In theory, this can give me access to Yandex S3 API