### PR TITLE
error with cloudstorage.ErrObjectNotFound when a reader is opened on a directory

### DIFF
--- a/localfs/store_test.go
+++ b/localfs/store_test.go
@@ -1,6 +1,7 @@
 package localfs_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -50,4 +51,40 @@ func TestAll(t *testing.T) {
 	store, err = cloudstorage.NewStore(localFsConf)
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, nil, store)
+}
+
+func TestNewReaderDir(t *testing.T) {
+	// When a dir is requested, serve the index.html file instead
+	localFsConf := &cloudstorage.Config{
+		Type:       localfs.StoreType,
+		AuthMethod: localfs.AuthFileSystem,
+		LocalFS:    "/tmp/mockcloud",
+		TmpDir:     "/tmp/localcache",
+	}
+	store, err := cloudstorage.NewStore(localFsConf)
+	testutils.MockFile(store, "test/index.html", "test")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, nil, err)
+	_, err = store.NewReader("test")
+	assert.Equal(t, err, cloudstorage.ErrObjectNotFound)
+	err = store.Delete(context.Background(), "test/index.html")
+	assert.Equal(t, nil, err)
+}
+
+func TestGetDir(t *testing.T) {
+	// When a dir is requested, serve the index.html file instead
+	localFsConf := &cloudstorage.Config{
+		Type:       localfs.StoreType,
+		AuthMethod: localfs.AuthFileSystem,
+		LocalFS:    "/tmp/mockcloud",
+		TmpDir:     "/tmp/localcache",
+	}
+	store, err := cloudstorage.NewStore(localFsConf)
+	testutils.MockFile(store, "test/index.html", "test")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, nil, err)
+	_, err = store.Get(context.Background(), "test")
+	assert.Equal(t, err, cloudstorage.ErrObjectNotFound)
+	err = store.Delete(context.Background(), "test/index.html")
+	assert.Equal(t, nil, err)
 }

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -903,3 +903,22 @@ func MultipleRW(t TestingT, store cloudstorage.Store, conf *cloudstorage.Config)
 		assert.Equal(t, nil, err)
 	}
 }
+
+func MockFile(store cloudstorage.Store, path string, body string) error {
+	obj, err := store.NewObject(path)
+	if err != nil {
+		return err
+	}
+	f, err := obj.Open(cloudstorage.ReadWrite)
+	if err != nil {
+		return err
+	}
+	w := bufio.NewWriter(f)
+
+	if _, err := w.WriteString(body); err != nil {
+		return err
+	}
+	w.Flush()
+	obj.Close()
+	return nil
+}


### PR DESCRIPTION
when a directory is requested with the google implementation, we get an error `cloudstorage.ErrObjectNotFound`, but when a directory is requested with the localfs implementation, we get an error "foo is a directory". This patch just makes the localfs implementation match the behavior of the google implementation